### PR TITLE
Get raml tool from our packages instead of building on the fly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "4.5.4"
+version = "4.6.0"
 
 java {
   toolchain {

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/base/BinInstallAction.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/base/BinInstallAction.kt
@@ -1,0 +1,24 @@
+package org.veupathdb.lib.gradle.container.tasks.base
+
+import org.gradle.api.tasks.Internal
+import java.io.File
+
+abstract class BinInstallAction: Action() {
+
+    /**
+     * Returns a reference to the output bin directory.
+     * <p>
+     * This method is the same as {@link #getDependencyRoot()} just with a more
+     * descriptive name.
+     *
+     * @return A reference to the output bin directory.
+     *
+     * @since 1.1.0
+     */
+    @Internal
+    protected fun getBinRoot(): File =
+        log.getter(File(RootDir, globalBuildConfiguration().binDirectory))
+
+    protected fun globalBuildConfiguration() = options.binBuilds
+
+}

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/base/exec/ExecAction.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/base/exec/ExecAction.kt
@@ -219,10 +219,9 @@ abstract class ExecAction : Action() {
           args[0],
           args[1],
           args[2])
-        else -> String.format("Executing command `%s %s %s ...`\n",
+        else -> String.format("Executing command `%s %s`\n",
           args[0],
-          args[1],
-          args[2])
+          args.subList(1, args.size).toString())
       }
     }
   }

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/InstallRaml4JaxRS.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/InstallRaml4JaxRS.kt
@@ -1,139 +1,73 @@
 package org.veupathdb.lib.gradle.container.tasks.jaxrs
 
-import org.veupathdb.lib.gradle.container.exec.Maven
-import org.veupathdb.lib.gradle.container.exec.git.Git
-import org.veupathdb.lib.gradle.container.tasks.base.build.BinBuildAction
+import org.veupathdb.lib.gradle.container.tasks.base.BinInstallAction
 
 import java.io.File
-import java.util.Stack
+import java.io.FileOutputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 /**
  * RAML 4 Jax-RS Generator Installation
  *
  * @since 1.1.0
  */
-open class InstallRaml4JaxRS : BinBuildAction() {
+open class InstallRaml4JaxRS : BinInstallAction() {
 
   companion object {
-    private const val LockFile = "raml4jaxrs.lock"
-
-    @JvmStatic
-    private val VersionMatch = Regex("\\d+\\.\\d+\\.\\d+-SNAPSHOT")
-
     const val TaskName = "install-raml-4-jax-rs"
 
     const val OutputFile = "raml-to-jaxrs.jar"
+
+    const val RamlToJaxrsDownloadLink = "https://github.com/VEuPathDB/maven-packages/blob/main/raw-packages/org/raml/jaxrs/3.0.7/raml-to-jaxrs-cli-3.0.7.jar?raw=true";
   }
 
-  override fun getDependencyName(): String {
-    return "Raml for JaxRS"
-  }
-
-  override fun getLockFile(): File {
-    return log.getter(File(getDependencyRoot(), LockFile))
+  override fun execute() {
+    createBuildRootIfNotExists();
+    install();
   }
 
   override val pluginDescription
-    get() = "Builds and installs the Raml for JaxRS generator."
+    get() = "Downloads and installs the Raml for JaxRS generator."
 
-  override fun clean() {}
-
-  override fun download(): File {
-    log.open()
-    log.info("Cloning {}", this::getDependencyName)
-
-    return log.close(Git(log).shallowClone(
-      buildConfiguration().url,
-      getDependencyRoot(),
-      buildConfiguration().targetVersion
-    ))
-  }
-
-  override fun install() {
+  private fun install() {
     log.open()
 
-    correctPoms(findPoms())
+    val res = HttpClient.newBuilder()
+      .followRedirects(HttpClient.Redirect.NEVER)
+      .build()
+      .send(
+        HttpRequest.newBuilder(
+          URI.create(RamlToJaxrsDownloadLink)
+        )
+          .GET()
+          .build(),
+        HttpResponse.BodyHandlers.ofInputStream()
+      )
+    val file = File(getBinRoot(), OutputFile)
+    log.info("Creating file at ${file.path}")
+    file.delete()
+    file.createNewFile()
 
-    log.info("Compiling {}", this::getDependencyName)
-
-    val mvn = Maven(log)
-    val dir = File(getBuildTargetDirectory(), "raml-to-jaxrs/raml-to-jaxrs-cli")
-
-    mvn.cleanInstall(dir)
-    mvn.findOutputJars(dir)
-      .filter { it.name.endsWith("dependencies.jar") }
-      .peek { log.debug("Installing jar %s", it) }
-      .forEach { util.moveFile(it, File(getBinRoot(), OutputFile)) }
+    log.info("Fetching raml tool from $RamlToJaxrsDownloadLink")
+    FileOutputStream(file).use {
+      res.body().transferTo(it)
+      it.flush()
+    }
 
     log.close()
   }
 
-  override fun buildConfiguration(): Raml4JaxRSBuildConfig {
-    return options.raml4jaxrs
-  }
-
-  /**
-   * Locates all the pom.xml files in the cloned raml-4-jax-rs Git repo.
-   *
-   * @return A list of all the pom.xml files in the cloned raml-4-jax-rs Git
-   * repo.
-   *
-   * @since 1.1.0
-   */
-  private fun findPoms(): List<File> {
+  protected fun createBuildRootIfNotExists() {
     log.open()
 
-    // Version 3.0.7 of raml-for-jax-rs contains 46 pom files
-    val poms = Stack<File>()
-    val dirs = Stack<File>()
+    val dir = getBinRoot()
 
-    dirs.push(getBuildTargetDirectory())
-
-    while (!dirs.empty()) {
-      val dir = dirs.pop()
-
-      log.debug("Gathering pom files from directory {}", dir)
-
-      //noinspection ConstantConditions
-      for (child in dir.listFiles()!!) {
-
-        if (child.isDirectory) {
-
-          if (!child.name.startsWith(".") && !child.name.equals("src"))
-            dirs.push(child)
-
-        } else if (child.name.equals("pom.xml")) {
-
-          log.debug("Located pom file {}", child)
-          poms.add(child)
-
-        }
-      }
-    }
-
-    return log.close(poms)
-  }
-
-  /**
-   * Monkey-patches the pom files in the given list to fix a build error from
-   * bad version values in the cloned pom files.
-   *
-   * @param poms Pom files to patch.
-   *
-   * @since 1.1.0
-   */
-  private fun correctPoms(poms: List<File>) {
-    log.open(poms)
-
-    log.info("Patching {} pom files", this::getDependencyName)
-
-    for (pom in poms) {
-      log.debug("Patching {}", pom)
-
-      util.overwriteFile(
-        pom,
-        VersionMatch.replace(util.readFile(pom), buildConfiguration().targetVersion)
-      )
+    if (!dir.exists() && !dir.mkdirs()) {
+      log.error("Failed to create build root $dir")
+      throw RuntimeException("Failed to create build root $dir")
     }
 
     log.close()

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/InstallRaml4JaxRS.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/InstallRaml4JaxRS.kt
@@ -21,7 +21,7 @@ open class InstallRaml4JaxRS : BinInstallAction() {
 
     const val OutputFile = "raml-to-jaxrs.jar"
 
-    const val RamlToJaxrsDownloadLink = "https://github.com/VEuPathDB/maven-packages/blob/main/raw-packages/org/raml/jaxrs/3.0.7/raml-to-jaxrs-cli-3.0.7.jar?raw=true";
+    const val RamlToJaxrsDownloadLink = "https://github.com/VEuPathDB/maven-packages/blob/main/raw-packages/org/raml/jaxrs/3.0.7/raml-to-jaxrs-cli-3.0.7-jar-with-dependencies.jar?raw=true"
   }
 
   override fun execute() {
@@ -36,7 +36,7 @@ open class InstallRaml4JaxRS : BinInstallAction() {
     log.open()
 
     val res = HttpClient.newBuilder()
-      .followRedirects(HttpClient.Redirect.NEVER)
+      .followRedirects(HttpClient.Redirect.ALWAYS)
       .build()
       .send(
         HttpRequest.newBuilder(
@@ -50,6 +50,8 @@ open class InstallRaml4JaxRS : BinInstallAction() {
     log.info("Creating file at ${file.path}")
     file.delete()
     file.createNewFile()
+
+    log.info("Received ${res.statusCode()} status from download URL")
 
     log.info("Fetching raml tool from $RamlToJaxrsDownloadLink")
     FileOutputStream(file).use {


### PR DESCRIPTION
This is a fixed version of my borked PR: https://github.com/VEuPathDB/lib-gradle-container-utils/pull/12

## Overview
Downloading pre-built jar for raml tool instead of downloading it.

## Testing
Not sure how to test this without creating a release. I'll look into this before merging.
