### PR TITLE
Initial try of download dependencies task

### DIFF
--- a/src/main/java/org/veupathdb/lib/gradle/container/ContainerUtilsPlugin.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/ContainerUtilsPlugin.kt
@@ -11,6 +11,7 @@ import org.veupathdb.lib.gradle.container.config.Options
 import org.veupathdb.lib.gradle.container.tasks.*
 import org.veupathdb.lib.gradle.container.tasks.base.Action
 import org.veupathdb.lib.gradle.container.tasks.check.CheckEnv
+import org.veupathdb.lib.gradle.container.tasks.check.DownloadDependencies
 import org.veupathdb.lib.gradle.container.tasks.docker.DockerBuild
 import org.veupathdb.lib.gradle.container.tasks.jaxrs.*
 import org.veupathdb.lib.gradle.container.tasks.raml.ExecMergeRaml
@@ -76,6 +77,8 @@ class ContainerUtilsPlugin : Plugin<Project> {
     tasks.create(PrintPackage.TaskName, PrintPackage::class.java, Action::init)
 
     tasks.create(CheckEnv.TaskName, CheckEnv::class.java, Action::init)
+
+    tasks.create(DownloadDependencies.TaskName, DownloadDependencies::class.java, DownloadDependencies::init)
 
     project.afterEvaluate { x -> afterEvaluate(x) }
   }

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/check/DownloadDependencies.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/check/DownloadDependencies.kt
@@ -14,7 +14,7 @@ import java.nio.file.Paths
  *
  * This allows the download of dependencies to be done in advance of a compile step,
  * which, when called as a separate step in a Dockerfile, can optimizing docker cache
- * hits since depencencies change more rarely than project source code.
+ * hits since dependencies change more rarely than project source code.
  */
 open class DownloadDependencies : Copy() {
 

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/check/DownloadDependencies.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/check/DownloadDependencies.kt
@@ -1,0 +1,47 @@
+package org.veupathdb.lib.gradle.container.tasks.check
+
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.Copy
+import org.veupathdb.lib.gradle.container.tasks.base.Action
+import java.nio.file.Paths
+
+/**
+ * This task creates a temporary '.dependencies' directory and asks Gradle to copy
+ * the files in the compile classpath into it.  This triggers a download of all
+ * declared dependencies, which are cached in the gradle cache before being copied
+ * into the temporary directory.  This task then deletes the temporary directory,
+ * leaving the downloaded dependencies in the gradle cache.
+ *
+ * This allows the download of dependencies to be done in advance of a compile step,
+ * which, when called as a separate step in a Dockerfile, can optimizing docker cache
+ * hits since depencencies change more rarely than project source code.
+ */
+open class DownloadDependencies : Copy() {
+
+    companion object {
+        const val TaskName = "download-dependencies"
+
+        @JvmStatic
+        fun init(action: DownloadDependencies) {
+            action.register();
+        }
+    }
+
+    fun register() {
+        description = "Downloads this projects dependencies, adding them to the gradle cache"
+        group = Action.Group
+        actions.add { execute() }
+    }
+
+    private val dependencyDir = Paths.get(".dependencies")
+
+    fun execute() {
+        project.mkdir(dependencyDir)
+        val ext = project.extensions.getByType(JavaPluginExtension::class.java);
+        val dependencies = ext.sourceSets.findByName("main")?.compileClasspath;
+        from(dependencies)
+        into(dependencyDir)
+        copy()
+        project.delete(dependencyDir)
+    }
+}


### PR DESCRIPTION
@Foxcapades Dan and I got this task working on Friday so we could download dependency jars in a Docker build step that didn't depend on the project's source.  It seemed to work putting this in EdaUserService's build.gradle.kts:
```
val dependencyDir = ".dependencies"
tasks.register("download-dependencies", Copy::class) {

  from(sourceSets.main.map(SourceSet::getRuntimeClasspath))
  into(dependencyDir)

  doFirst {
    ant {
      delete(dependencyDir)
      mkdir(dependencyDir)
    }
  }

  doLast {
    ant {
      delete(dependencyDir)
    }
  }
}
```
So this PR is an attempt to replicate that code as a callable task in any project.