### PR TITLE
correct enum patch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "4.7.3"
+version = "4.8.0"
 
 java {
   toolchain {

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchEnumValue.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchEnumValue.kt
@@ -11,7 +11,7 @@ open class JaxRSPatchEnumValue : JaxRSSourceAction() {
     const val TaskName = "jaxrs-patch-enums"
 
     private const val OldNameField = "  private String name;"
-    private const val NewNameField = "  public final String value;"
+    private const val NewNameField = "  private final String value;"
 
     private const val OldNameSetter = "    this.name = name;"
     private const val NewNameSetter = "    this.value = name;"

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchEnumValue.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchEnumValue.kt
@@ -4,26 +4,17 @@ import org.veupathdb.lib.gradle.container.tasks.base.JaxRSSourceAction
 
 import java.io.*
 import java.util.Arrays
-import java.util.Locale
 
 open class JaxRSPatchEnumValue : JaxRSSourceAction() {
 
   companion object {
     const val TaskName = "jaxrs-patch-enums"
 
-    private const val OldLeader = "  private "
-    private const val NewLeader = "  public final "
+    private const val OldNameField = "  private String name;"
+    private const val NewNameField = "  public final String value;"
 
-    private const val Getter1 = "\n\n  public "
-    private const val Getter2 = " get"
-    private const val Getter3 = "() {\n" +
-    "    return this."
-    private const val Getter4 = ";\n" +
-    "  }\n"
-    private const val GetterLength = Getter1.length +
-      Getter2.length +
-      Getter3.length +
-      Getter4.length
+    private const val OldNameSetter = "    this.name = name;"
+    private const val NewNameSetter = "    this.value = name;"
   }
 
   override fun execute() {
@@ -64,8 +55,6 @@ open class JaxRSPatchEnumValue : JaxRSSourceAction() {
   }
 
   private fun patchContents(from: File, to: File) {
-    var getter: String? = null
-
     BufferedReader(FileReader(from)).use { reader ->
       BufferedWriter(FileWriter(to)).use { writer ->
         var i = 0
@@ -73,17 +62,19 @@ open class JaxRSPatchEnumValue : JaxRSSourceAction() {
           val line = reader.readLine() ?: break
           i++
 
-          if (line.startsWith(OldLeader)) {
-            writer.write(NewLeader)
-            val end = line.substring(OldLeader.length)
-            getter = assembleGetter(end)
-            writer.write(end)
-          } else if (getter != null && "}" == line) {
-            writer.write(getter!!)
-            writer.write(line)
-          } else {
-            writer.write(line)
+          when {
+            line.startsWith(OldNameField)  -> writer.write(NewNameField)
+
+            line.startsWith(OldNameSetter) -> writer.write(NewNameSetter)
+
+            line == "}"                    -> {
+              writer.write(generateValueGetter())
+              writer.write(line)
+            }
+
+            else                           -> writer.write(line)
           }
+
           writer.newLine()
         }
 
@@ -101,22 +92,9 @@ open class JaxRSPatchEnumValue : JaxRSSourceAction() {
   //                                                                                            //
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
+  private fun generateValueGetter() =
+    "  public String getValue() {\n" +
+    "    return this.value;\n" +
+    "  }\n"
 
-  private fun assembleGetter(line: String): String {
-    val x = line.indexOf(' ')
-    val y = line.indexOf(';', x)
-
-    return assembleGetter(line.substring(0, x), line.substring(x+1, y))
-  }
-
-  private fun assembleGetter(type: String, name: String): String {
-    return Getter1 +
-      type +
-      Getter2 +
-      name.substring(0, 1).toUpperCase(Locale.ROOT) +
-      name.substring(1) +
-      Getter3 +
-      name +
-      Getter4
-  }
 }


### PR DESCRIPTION
undoes the breaking change that was made to the enum patch process that changed the name of the getValue function to getName.