### PR TITLE
Patch response type member visibilities.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "org.veupathdb.lib"
-version = "6.0.0"
+version = "6.1.0"
 
 java {
   sourceCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/org/veupathdb/lib/gradle/container/ContainerUtilsPlugin.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/ContainerUtilsPlugin.kt
@@ -57,26 +57,36 @@ class ContainerUtilsPlugin : Plugin<Project> {
 
     val init: (Action) -> Unit = { Action.init(it) }
 
-    tasks.register(InstallRaml4JaxRS.TaskName, InstallRaml4JaxRS::class.java, init)
-    tasks.register(UninstallRaml4JaxRS.TaskName, UninstallRaml4JaxRS::class.java, init)
+    arrayOf(
+      // RAML Merge
+      InstallMergeRaml.TaskName to InstallMergeRaml::class,
+      ExecMergeRaml.TaskName to ExecMergeRaml::class,
 
-    tasks.register(GenerateJaxRS.TaskName, GenerateJaxRS::class.java, init)
-    tasks.register(GenerateRamlDocs.TaskName, GenerateRamlDocs::class.java, init)
+      // JaxRS Code Generation
+      InstallRaml4JaxRS.TaskName to InstallRaml4JaxRS::class,
+      UninstallRaml4JaxRS.TaskName to UninstallRaml4JaxRS::class,
 
-    tasks.register(InstallMergeRaml.TaskName, InstallMergeRaml::class.java, init)
-    tasks.register(ExecMergeRaml.TaskName, ExecMergeRaml::class.java, init)
+      GenerateJaxRS.TaskName to GenerateJaxRS::class,
+      GenerateRamlDocs.TaskName to GenerateRamlDocs::class,
 
-    tasks.register(JaxRSPatchDiscriminators.TaskName, JaxRSPatchDiscriminators::class.java, init)
-    tasks.register(JaxRSPatchEnumValue.TaskName, JaxRSPatchEnumValue::class.java, init)
-    tasks.register(JaxRSGenerateStreams.TaskName, JaxRSGenerateStreams::class.java, init)
-    tasks.register(JaxRSPatchJakartaImports.TaskName, JaxRSPatchJakartaImports::class.java, init)
-    tasks.register(JaxRSPatchBoxedTypes.TaskName, JaxRSPatchBoxedTypes::class.java, init)
-    tasks.register(JaxRSPatchFileResponses.TaskName, JaxRSPatchFileResponses::class.java, init)
-    tasks.register(JaxRSPatchDates.TaskName, JaxRSPatchDates::class.java, init)
+      JaxRSPatchDiscriminators.TaskName to JaxRSPatchDiscriminators::class,
+      JaxRSPatchEnumValue.TaskName to JaxRSPatchEnumValue::class,
+      JaxRSGenerateStreams.TaskName to JaxRSGenerateStreams::class,
+      JaxRSPatchJakartaImports.TaskName to JaxRSPatchJakartaImports::class,
+      JaxRSPatchBoxedTypes.TaskName to JaxRSPatchBoxedTypes::class,
+      JaxRSPatchFileResponses.TaskName to JaxRSPatchFileResponses::class,
+      JaxRSPatchDates.TaskName to JaxRSPatchDates::class,
+      JaxRSPatchResponseDelegate.TaskName to JaxRSPatchResponseDelegate::class,
+      JaxRSPatchResponseTypes.TaskName to JaxRSPatchResponseTypes::class,
 
-    tasks.register(DockerBuild.TaskName, DockerBuild::class.java, init)
+      // Docker
+      DockerBuild.TaskName to DockerBuild::class,
 
-    tasks.register(CheckEnv.TaskName, CheckEnv::class.java, init)
+      // Utilities
+      CheckEnv.TaskName to CheckEnv::class,
+    ).forEach { (name, type) ->
+      tasks.register(name, type.java, init)
+    }
 
     tasks.register(DownloadDependencies.TaskName, DownloadDependencies::class.java, DownloadDependencies::init)
 
@@ -115,6 +125,8 @@ class ContainerUtilsPlugin : Plugin<Project> {
       JaxRSPatchBoxedTypes.TaskName,
       JaxRSPatchFileResponses.TaskName,
       JaxRSPatchDates.TaskName,
+      JaxRSPatchResponseDelegate.TaskName,
+      JaxRSPatchResponseTypes.TaskName,
     )
 
     // Register merge raml dependencies

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/base/SourceAction.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/base/SourceAction.kt
@@ -6,7 +6,6 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 
 import java.io.File
-import java.util.stream.Stream
 
 abstract class SourceAction : Action() {
 
@@ -16,7 +15,7 @@ abstract class SourceAction : Action() {
   }
 
   @Internal
-  protected fun getProjectSourceDirectories(): Stream<File> {
+  protected fun getProjectSourceDirectories(): Sequence<File> {
     log.open()
 
     val projectPath = projectConfig().projectPackage.replace('.', '/')
@@ -37,13 +36,13 @@ abstract class SourceAction : Action() {
    * @return Stream of source directories.
    */
   @Internal
-  protected fun getSourceDirectories(): Stream<File> =
+  protected fun getSourceDirectories(): Sequence<File> =
     log.getter(
       getSourceSets()
-        .stream()
+        .asSequence()
         .map(SourceSet::getAllSource)
         .map(SourceDirectorySet::getSrcDirs)
-        .flatMap(Collection<File>::stream)
+        .flatMap(Collection<File>::asSequence)
         .filter(File::exists))
 
   /**
@@ -56,23 +55,23 @@ abstract class SourceAction : Action() {
    * @return Stream of resource directories.
    */
   @Internal
-  protected fun getResourceDirectories(): Stream<File> {
+  protected fun getResourceDirectories(): Sequence<File> {
     log.open()
 
     var out = getSourceSets()
-      .stream()
+      .asSequence()
       .map(SourceSet::getResources)
       .map(SourceDirectorySet::getSrcDirs)
-      .flatMap(Collection<File>::stream)
+      .flatMap(Collection<File>::asSequence)
 
     if (log.isDebug) {
-      out = out.peek(newFileLogger(LogResDirsCheck))
+      out = out.onEach(newFileLogger(LogResDirsCheck))
     }
 
     out = out.filter(File::exists)
 
     if (log.isDebug) {
-      out = out.peek(newFileLogger(LogResDirsFound))
+      out = out.onEach(newFileLogger(LogResDirsFound))
     }
 
     return log.close(out)

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchDates.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchDates.kt
@@ -24,10 +24,10 @@ open class JaxRSPatchDates : JaxRSSourceAction() {
     get() = "Replaces usage of the deprecated Java Date API with OffsetDateTime."
 
   override fun execute() {
-    Stream.concat(getGeneratedModelDirectories(), getGeneratedResourceDirectories())
-      .map { it.listFiles() }
-      .filter { it != null }
-      .flatMap { Arrays.stream(it) }
+    (getGeneratedModelDirectories() + getGeneratedResourceDirectories())
+      .map(File::listFiles)
+      .filterNotNull()
+      .flatMap { it.asSequence() }
       .filter { it.name.endsWith(".java") }
       .filter { it.name != "TimestampDeserializer.java" }
       .forEach { processFile(it) }

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchDiscriminators.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchDiscriminators.kt
@@ -3,8 +3,6 @@ package org.veupathdb.lib.gradle.container.tasks.jaxrs
 import org.veupathdb.lib.gradle.container.tasks.base.JaxRSSourceAction
 
 import java.io.*
-import java.util.Arrays
-import java.util.Locale
 
 open class JaxRSPatchDiscriminators : JaxRSSourceAction() {
 
@@ -41,9 +39,9 @@ open class JaxRSPatchDiscriminators : JaxRSSourceAction() {
 
     // Filter the list of directories down to only those that actually exist.
     stream = if (log.isDebug) {
-      stream.peek(newFileLogger(LogModelDirCheck))
+      stream.onEach(newFileLogger(LogModelDirCheck))
         .filter(File::exists)
-        .peek(newFileLogger(LogModelDirFound))
+        .onEach(newFileLogger(LogModelDirFound))
     } else {
       stream.filter(File::exists)
     }
@@ -51,14 +49,15 @@ open class JaxRSPatchDiscriminators : JaxRSSourceAction() {
     // Expand the stream to all the files in each directory, then filter the
     // expanded file stream down to only files that appear to be interfaces.
     stream = stream.map(File::listFiles)
-      .flatMap(Arrays::stream)
+      .filterNotNull()
+      .flatMap { it.asSequence() }
       // Filter out implementation files
       .filter(this::nonImplPredicate)
       // Filter ot non-java files
       .filter(this::javaFilePredicate)
 
     if (log.isDebug) {
-      stream = stream.peek(newFileLogger(LogJavaFileCheck))
+      stream = stream.onEach(newFileLogger(LogJavaFileCheck))
     }
 
     // Sift through each file looking for

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchEnumValue.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchEnumValue.kt
@@ -30,9 +30,10 @@ open class JaxRSPatchEnumValue : JaxRSSourceAction() {
 
     getGeneratedModelDirectories()
       .map(File::listFiles)
-      .flatMap(Arrays::stream)
+      .filterNotNull()
+      .flatMap { it.asSequence() }
       .filter(this::enumFilter)
-      .peek { counter++ }
+      .onEach { counter++ }
       .forEach(this::patch)
 
     log.info("Patched {} enum files", counter)

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchFileResponses.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchFileResponses.kt
@@ -36,18 +36,18 @@ open class JaxRSPatchFileResponses : JaxRSSourceAction() {
     // Get a stream over the resource directories
     getGeneratedResourceDirectories()
       // Map to a stream of arrays of files contained in those directories
-      .map { it.listFiles() }
+      .map(File::listFiles)
       // It won't here, but technically listFiles can return null
-      .filter { it != null }
+      .filterNotNull()
       // Flat map our stream of arrays to a stream of files contained in the
       // resource directories.
-      .flatMap { Arrays.stream(it) }
+      .flatMap { it.asSequence() }
       // Filter our stream down to only java files
       .filter { it.name.endsWith(".java") }
       // Filter our stream down to only those files that contain a File import.
       .filter { testFile(it) }
       // Log what we're doing
-      .peek { log.info("Processing file {}", it) }
+      .onEach { log.info("Processing file {}", it) }
       // Process the files
       .forEach { processFile(it) }
   }

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchJakartaImports.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchJakartaImports.kt
@@ -4,8 +4,6 @@ import org.veupathdb.lib.gradle.container.tasks.base.JaxRSSourceAction
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.File
-import java.util.Arrays
-import java.util.stream.Stream
 
 open class JaxRSPatchJakartaImports : JaxRSSourceAction() {
 
@@ -24,16 +22,17 @@ open class JaxRSPatchJakartaImports : JaxRSSourceAction() {
 
     // Get all the generated source root directories
     getGeneratedSourceDirectories()
-      .flatMap { Stream.of(                 // Expand the stream to the 2 relevant subdirectories
-        File(it, GeneratedResourceDirectory),
-        File(it, GeneratedSupportDirectory)
-      ) }
+      // Expand the stream to the 2 relevant subdirectories
+      .flatMap { sequence {
+        yield(File(it, GeneratedResourceDirectory))
+        yield(File(it, GeneratedSupportDirectory))
+      } }
       .filter { it.exists() }               // Filter out any erroneous paths
       .map { it.listFiles() }               // Map to lists of files in each directory
-      .filter { it != null }                // Filter out any erroneous entries (just to be safe)
-      .flatMap { Arrays.stream(it) }        // Expand the stream to a stream of files
+      .filterNotNull()                      // Filter out any erroneous entries (just to be safe)
+      .flatMap { it.asSequence() }          // Expand the stream to a stream of files
       .filter { it.name.endsWith(".java") } // Filter the stream down to just java files
-      .forEach { processFile(it) }
+      .forEach(::processFile)
 
     log.close()
   }

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchJakartaImports.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchJakartaImports.kt
@@ -32,25 +32,12 @@ open class JaxRSPatchJakartaImports : JaxRSSourceAction() {
       .filterNotNull()                      // Filter out any erroneous entries (just to be safe)
       .flatMap { it.asSequence() }          // Expand the stream to a stream of files
       .filter { it.name.endsWith(".java") } // Filter the stream down to just java files
-      .forEach(::processFile)
+      .forEach { processFile(it, ::processContents) }
 
     log.close()
   }
 
-  private fun processFile(file: File) {
-    val tmpFile = File("${file.path}.tmp")
-    tmpFile.createNewFile()
-
-    tmpFile.bufferedWriter().use { output ->
-      file.bufferedReader().use { input -> processContents(output, input) }
-      output.flush()
-    }
-
-    tmpFile.copyTo(file, true)
-    tmpFile.delete()
-  }
-
-  private fun processContents(output: BufferedWriter, input: BufferedReader) {
+  private fun processContents(input: BufferedReader, output: BufferedWriter) {
     var line = input.readLine()
 
     while (line != null) {

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchResponseDelegate.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchResponseDelegate.kt
@@ -1,0 +1,91 @@
+package org.veupathdb.lib.gradle.container.tasks.jaxrs
+
+import org.veupathdb.lib.gradle.container.tasks.base.JaxRSSourceAction
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+
+open class JaxRSPatchResponseDelegate: JaxRSSourceAction() {
+  companion object {
+    const val TaskName = "jaxrs-patch-response-delegate"
+
+    private const val PrivatePrefix = "private"
+    private const val ProtectedPrefix = "protected"
+    private const val PublicPrefix = "public"
+  }
+
+  override val pluginDescription: String
+    get() = "Patches the generated ResponseDelegate class to enable direct" +
+    " usage of properties and constructors."
+
+  override fun execute() {
+    log.open()
+
+    getGeneratedSupportDirectories()
+      .map(File::listFiles)
+      .filterNotNull()
+      .flatMap { it.asSequence() }
+      .filter { it.name == "ResponseDelegate.java" }
+      .forEach { processFile(it, ::processClass) }
+
+    log.close()
+  }
+
+  private fun processClass(input: BufferedReader, output: BufferedWriter) {
+    val lines = input.lineSequence().iterator()
+
+    // Skip until the class starts
+    for (line in lines) {
+      output.writeLine(line)
+      if (line.startsWith("public class"))
+        break
+    }
+
+    // Process relevant class contents
+    for (line in lines) {
+
+      // Change visibility of private properties.
+      var i = line.indexOf(PrivatePrefix)
+      if (i > -1) {
+        line.patchToPublic(i, PrivatePrefix, output)
+        output.newLine()
+        continue
+      }
+
+      // Change visibility of constructors
+      i = line.indexOf(ProtectedPrefix)
+      if (i > -1) {
+        line.patchToPublic(i, ProtectedPrefix, output)
+
+        // Write out the rest of the constructor body
+        for (l in lines) {
+          output.writeLine(l)
+          if (l.endsWith('}')) {
+            output.newLine()
+            break
+          }
+        }
+
+        continue
+      }
+
+      // Stop processing at first method
+      if (line.contains("@Override")) {
+        output.writeLine(line)
+        break
+      }
+    }
+
+    // Copy out the rest unchanged
+    for (line in lines) {
+      output.writeLine(line)
+    }
+  }
+
+  private fun String.patchToPublic(hit: Int, prefix: String, output: BufferedWriter) {
+    output.write(substring(0, hit))
+    output.write(PublicPrefix)
+    output.write(substring(hit + prefix.length))
+    output.newLine()
+  }
+}

--- a/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchResponseTypes.kt
+++ b/src/main/java/org/veupathdb/lib/gradle/container/tasks/jaxrs/JaxRSPatchResponseTypes.kt
@@ -1,0 +1,102 @@
+package org.veupathdb.lib.gradle.container.tasks.jaxrs
+
+import org.veupathdb.lib.gradle.container.tasks.base.JaxRSSourceAction
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+
+open class JaxRSPatchResponseTypes: JaxRSSourceAction() {
+  companion object {
+    const val TaskName = "jaxrs-patch-response-types"
+
+    private const val PrivatePrefix = "private"
+    private const val ProtectedPrefix = "protected"
+    private const val PublicPrefix = "public"
+
+    private val ResponseClassPattern = Regex("^ +class (\\w+) extends ResponseDelegate \\{$")
+  }
+
+  override val pluginDescription: String
+    get() = "Patches the generated response type classes to make constructors" +
+    " public."
+
+  override fun execute() {
+    log.open()
+
+    getGeneratedResourceDirectories()
+      .map(File::listFiles)
+      .filterNotNull()
+      .flatMap { it.asSequence() }
+      .filter { it.name.endsWith(".java") }
+      .forEach { processFile(it, ::processClass) }
+
+    log.close()
+  }
+
+  private fun processClass(input: BufferedReader, output: BufferedWriter) {
+    val lines = input.lineSequence().iterator()
+
+    // Process relevant class contents
+    while (lines.hasNext()) {
+      val className = skipUntilResponseClass(lines, output) ?: continue
+      var firstMethodLine: String? = null
+
+      // Patch constructor visibilities
+      for (line in lines) {
+        val i = line.indexOf(PrivatePrefix)
+        if (i > -1) {
+          line.patchToPublic(i, PrivatePrefix, output)
+
+          // Write out the rest of the constructor body
+          for (l in lines) {
+            output.writeLine(l)
+            if (l.endsWith('}')) {
+              output.newLine()
+              break
+            }
+          }
+
+          continue
+        }
+
+        // Stop once we hit the first method (which will be public)
+        if (line.contains(PublicPrefix)) {
+          firstMethodLine = line
+          break
+        }
+      }
+
+      // Inject a new constructor
+      output.writeLine(createCopyConstructor(className))
+      output.newLine()
+
+      output.writeLine(firstMethodLine!!)
+    }
+  }
+
+  private fun skipUntilResponseClass(lines: Iterator<String>, output: BufferedWriter): String? {
+    for (line in lines) {
+      output.writeLine(line)
+      if (line.contains("class")) {
+        val match = ResponseClassPattern.matchEntire(line) ?: continue
+        return match.groups[1]!!.value
+      }
+    }
+
+    return null
+  }
+
+  private fun String.patchToPublic(hit: Int, prefix: String, output: BufferedWriter) {
+    output.write(substring(0, hit))
+    output.write(PublicPrefix)
+    output.write(substring(hit + prefix.length))
+    output.newLine()
+  }
+
+  private fun createCopyConstructor(className: String) = """
+      |    public $className(ResponseDelegate response) {
+      |      super(response.delegate, response.entity);
+      |    }
+    """.trimMargin()
+
+}


### PR DESCRIPTION
## Features

Adds 2 new tasks:
1. `JaxRSPatchResponseDelegate` - Patches the support.ResponseDelegate class to make the `delegate` property, `entity` property and both constructors public.
2. `JaxRSPatchResponseType` - Patches generated response type objects to make the existing constructors public and to add a new generalized copy constructor which accepts any `ResponseDelegate` type (so any other response type).

## Changes

1. Move task registration to a loop as it was a pain to manage.
2. Convert usages of Java's `Stream` type to Kotlin's `Sequence` type.
3. Moves the common logic for file processing in JaxRS patches to the parent JaxRS patch task type.